### PR TITLE
feat(ngx-numeric-range-form-field): quality-pass — fix ±Infinity, expose label/native/error-kind APIs, a11y wiring

### DIFF
--- a/libs/ngx-numeric-range-form-field/README.md
+++ b/libs/ngx-numeric-range-form-field/README.md
@@ -27,8 +27,13 @@ Angular Material, no third-party runtime dependencies.
   (`[formField]`)
 - Ships four composable validator helpers — `numericRangeOrderValid`,
   `numericRangeBounds`, `numericRangeBothFilled`, `numericRangeWidth`
+- Typed `NumericRangeErrorKind` contract for error-key matching
 - Schema-driven validation (`required`, `readonly`, `disabled`, `validate`, …)
   owned by the consumer's `form()` definition
+- Accessible by default — visible label wires to the group via
+  `aria-labelledby`; per-input announcements compose `<group> <side>`
+- Native numeric-input attributes pass-through (`step`, `autocomplete`, per-side
+  `name` / `min` / `max`)
 - Custom outlined field styling — reskin via CSS custom properties without
   `::ng-deep`
 - Tree-shakable (`sideEffects: false`)
@@ -106,20 +111,28 @@ All inputs are signal inputs. Inputs marked **(schema-driven)** are
 automatically written by the `FormField` directive from the attached `form()`
 schema — bind them directly only when using the component without `[formField]`.
 
-| Input                      | Type                                               | Default  | Description                                                                          |
-| -------------------------- | -------------------------------------------------- | -------- | ------------------------------------------------------------------------------------ |
-| `label`                    | `string`                                           | `''`     | Label rendered above the field.                                                      |
-| `minPlaceholder`           | `string`                                           | `'From'` | Placeholder for the minimum input.                                                   |
-| `maxPlaceholder`           | `string`                                           | `'To'`   | Placeholder for the maximum input.                                                   |
-| `resettable`               | `boolean`                                          | `true`   | Show the reset (✕) button when a value is present.                                   |
-| `minReadonly`              | `boolean`                                          | `false`  | Make the minimum input read-only while the maximum remains editable.                 |
-| `maxReadonly`              | `boolean`                                          | `false`  | Mirror of `minReadonly` for the maximum input.                                       |
-| `value` (schema-driven)    | `INumericRange \| null`                            | `null`   | Composite value. Two-way via `[(value)]` or through `form()`.                        |
-| `disabled` (schema-driven) | `boolean`                                          | `false`  | Disable both inputs.                                                                 |
-| `readonly` (schema-driven) | `boolean`                                          | `false`  | Render both inputs read-only.                                                        |
-| `required` (schema-driven) | `boolean`                                          | `false`  | Show the required marker on the label.                                               |
-| `touched` (schema-driven)  | `boolean`                                          | `false`  | Marks the field as touched — flips the invalid styling on when paired with `errors`. |
-| `errors` (schema-driven)   | `readonly ValidationError.WithOptionalFieldTree[]` | `[]`     | Error list. Non-empty + touched paints the field red.                                |
+| Input                      | Type                                               | Default         | Description                                                                                                                                               |
+| -------------------------- | -------------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `label`                    | `string`                                           | `''`            | Visible label rendered above the field. When set, becomes the group's `aria-labelledby` target.                                                           |
+| `minPlaceholder`           | `string`                                           | `'From'`        | Placeholder for the minimum input.                                                                                                                        |
+| `maxPlaceholder`           | `string`                                           | `'To'`          | Placeholder for the maximum input.                                                                                                                        |
+| `minLabel`                 | `string \| null`                                   | `null`          | Override the minimum input's accessible name. Defaults to `minPlaceholder` when `null`.                                                                   |
+| `maxLabel`                 | `string \| null`                                   | `null`          | Override the maximum input's accessible name. Defaults to `maxPlaceholder` when `null`.                                                                   |
+| `resetLabel`               | `string`                                           | `'Reset range'` | `aria-label` for the reset (✕) button.                                                                                                                    |
+| `resettable`               | `boolean`                                          | `true`          | Show the reset (✕) button when a value is present.                                                                                                        |
+| `minReadonly`              | `boolean`                                          | `false`         | Make the minimum input read-only while the maximum remains editable.                                                                                      |
+| `maxReadonly`              | `boolean`                                          | `false`         | Mirror of `minReadonly` for the maximum input.                                                                                                            |
+| `step`                     | `number \| string \| null`                         | `null`          | Native `step` attribute forwarded to both inputs (e.g. `0.5`).                                                                                            |
+| `autocomplete`             | `string \| null`                                   | `null`          | Native `autocomplete` attribute forwarded to both inputs (e.g. `'off'`).                                                                                  |
+| `minName` / `maxName`      | `string \| null`                                   | `null`          | Per-side native `name` attribute — useful inside a native `<form>`.                                                                                       |
+| `minMin` / `minMax`        | `number \| string \| null`                         | `null`          | Per-side native HTML `min` / `max` attributes for the **minimum** input. Steers the browser spinner only — schema validation remains the source of truth. |
+| `maxMin` / `maxMax`        | `number \| string \| null`                         | `null`          | Per-side native HTML `min` / `max` for the **maximum** input.                                                                                             |
+| `value` (schema-driven)    | `INumericRange \| null`                            | `null`          | Composite value. Two-way via `[(value)]` or through `form()`.                                                                                             |
+| `disabled` (schema-driven) | `boolean`                                          | `false`         | Disable both inputs.                                                                                                                                      |
+| `readonly` (schema-driven) | `boolean`                                          | `false`         | Render both inputs read-only.                                                                                                                             |
+| `required` (schema-driven) | `boolean`                                          | `false`         | Show the required marker on the label. Visual flag — the actual validity comes from your `form()` schema.                                                 |
+| `touched` (schema-driven)  | `boolean`                                          | `false`         | Marks the field as touched — flips the invalid styling on when paired with `errors`.                                                                      |
+| `errors` (schema-driven)   | `readonly ValidationError.WithOptionalFieldTree[]` | `[]`            | Error list. Non-empty + touched paints the field red.                                                                                                     |
 
 ## Schema validators
 
@@ -197,6 +210,39 @@ Reading errors in a template:
 <p class="error">{{ err.message || err.kind }}</p>
 }
 ```
+
+### Typed error-kind contract
+
+Filter errors by typed constants instead of duplicating string literals:
+
+```typescript
+import { NumericRangeErrorKind } from 'ngx-numeric-range-form-field'
+
+const hasOrderError = rangeForm()
+  .errors()
+  .some(e => e.kind === NumericRangeErrorKind.OutOfOrder)
+```
+
+| Constant                           | Emitted by                         | `kind` value     |
+| ---------------------------------- | ---------------------------------- | ---------------- |
+| `NumericRangeErrorKind.OutOfOrder` | `numericRangeOrderValid`           | `'invalidRange'` |
+| `NumericRangeErrorKind.BoundsMin`  | `numericRangeBounds` (lower bound) | `'min'`          |
+| `NumericRangeErrorKind.BoundsMax`  | `numericRangeBounds` (upper bound) | `'max'`          |
+| `NumericRangeErrorKind.Incomplete` | `numericRangeBothFilled`           | `'incomplete'`   |
+| `NumericRangeErrorKind.WidthMin`   | `numericRangeWidth` (lower span)   | `'minWidth'`     |
+| `NumericRangeErrorKind.WidthMax`   | `numericRangeWidth` (upper span)   | `'maxWidth'`     |
+
+The string values match the kinds the validators emit today, so existing
+comparisons against the raw strings keep working.
+
+## Accessibility
+
+When `label` is set the component wires the visible label to the `role="group"`
+via `aria-labelledby` using stable per-instance IDs, and each input's
+`aria-label` composes `<group label> <side label>` — a screen reader announces
+e.g. _"Price range From"_ and _"Price range To"_ instead of just _"From"_ /
+_"To"_. Override the per-side announcement with `minLabel` / `maxLabel`, or the
+reset button announcement with `resetLabel`.
 
 ## Styling
 

--- a/libs/ngx-numeric-range-form-field/src/index.ts
+++ b/libs/ngx-numeric-range-form-field/src/index.ts
@@ -6,3 +6,4 @@ export { numericRangeBothFilled } from './lib/validators/numeric-range-both-fill
 export { numericRangeWidth } from './lib/validators/numeric-range-width'
 export type { NumericRangeWidthBounds } from './lib/validators/numeric-range-width'
 export type { INumericRange } from './lib/numeric-range.model'
+export { NumericRangeErrorKind } from './lib/error-kinds'

--- a/libs/ngx-numeric-range-form-field/src/lib/error-kinds.spec.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/error-kinds.spec.ts
@@ -1,0 +1,94 @@
+import { signal } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { form, required } from '@angular/forms/signals'
+import { NumericRangeErrorKind } from './error-kinds'
+import { INumericRange } from './numeric-range.model'
+import { numericRangeBothFilled } from './validators/numeric-range-both-filled'
+import { numericRangeBounds } from './validators/numeric-range-bounds'
+import { numericRangeOrderValid } from './validators/numeric-range-order'
+import { numericRangeWidth } from './validators/numeric-range-width'
+
+describe('NumericRangeErrorKind', () => {
+  it('OutOfOrder matches the kind emitted by numericRangeOrderValid', () => {
+    const value = signal<INumericRange | null>({ minimum: 9, maximum: 1 })
+    const field = TestBed.runInInjectionContext(() =>
+      form<INumericRange | null>(value, p => {
+        numericRangeOrderValid(p)
+      })
+    )
+    expect(
+      field()
+        .errors()
+        .map(e => e.kind)
+    ).toContain(NumericRangeErrorKind.OutOfOrder)
+  })
+
+  it('BoundsMin / BoundsMax match the kinds emitted by numericRangeBounds', () => {
+    const value = signal<INumericRange | null>({ minimum: -5, maximum: 50 })
+    const field = TestBed.runInInjectionContext(() =>
+      form<INumericRange | null>(value, p => {
+        numericRangeBounds(p, { min: 0, max: 10 })
+      })
+    )
+    const kinds = field()
+      .errors()
+      .map(e => e.kind)
+    expect(kinds).toContain(NumericRangeErrorKind.BoundsMin)
+    expect(kinds).toContain(NumericRangeErrorKind.BoundsMax)
+  })
+
+  it('Incomplete matches the kind emitted by numericRangeBothFilled', () => {
+    const value = signal<INumericRange | null>({ minimum: 1, maximum: null })
+    const field = TestBed.runInInjectionContext(() =>
+      form<INumericRange | null>(value, p => {
+        numericRangeBothFilled(p)
+      })
+    )
+    expect(
+      field()
+        .errors()
+        .map(e => e.kind)
+    ).toContain(NumericRangeErrorKind.Incomplete)
+  })
+
+  it('WidthMin / WidthMax match the kinds emitted by numericRangeWidth', () => {
+    const minValue = signal<INumericRange | null>({ minimum: 1, maximum: 2 })
+    const minField = TestBed.runInInjectionContext(() =>
+      form<INumericRange | null>(minValue, p => {
+        numericRangeWidth(p, { min: 10 })
+      })
+    )
+    expect(
+      minField()
+        .errors()
+        .map(e => e.kind)
+    ).toContain(NumericRangeErrorKind.WidthMin)
+
+    const maxValue = signal<INumericRange | null>({ minimum: 1, maximum: 100 })
+    const maxField = TestBed.runInInjectionContext(() =>
+      form<INumericRange | null>(maxValue, p => {
+        numericRangeWidth(p, { max: 10 })
+      })
+    )
+    expect(
+      maxField()
+        .errors()
+        .map(e => e.kind)
+    ).toContain(NumericRangeErrorKind.WidthMax)
+  })
+
+  it('coexists with the existing required() rule without overlapping kinds', () => {
+    const value = signal<INumericRange | null>(null)
+    const field = TestBed.runInInjectionContext(() =>
+      form<INumericRange | null>(value, p => {
+        required(p)
+      })
+    )
+    const kinds = field()
+      .errors()
+      .map(e => e.kind)
+    expect(kinds).toContain('required')
+    // None of the library-defined kinds collide with `required`.
+    expect(Object.values(NumericRangeErrorKind)).not.toContain('required')
+  })
+})

--- a/libs/ngx-numeric-range-form-field/src/lib/error-kinds.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/error-kinds.ts
@@ -1,0 +1,28 @@
+/**
+ * Error `kind` values emitted by this library's validators. Exporting them
+ * as a const-object lets consumers use the typed constants instead of
+ * duplicating string literals when filtering `field().errors()`:
+ *
+ * ```ts
+ * import { NumericRangeErrorKind } from 'ngx-numeric-range-form-field'
+ *
+ * if (field().errors().some(e => e.kind === NumericRangeErrorKind.OutOfOrder)) {
+ *   // …
+ * }
+ * ```
+ *
+ * The string values are the same as the `kind` strings emitted by the
+ * validators today, so existing code that compares against `'invalidRange'`,
+ * `'min'`, etc. continues to work.
+ */
+export const NumericRangeErrorKind = {
+  OutOfOrder: 'invalidRange',
+  BoundsMin: 'min',
+  BoundsMax: 'max',
+  Incomplete: 'incomplete',
+  WidthMin: 'minWidth',
+  WidthMax: 'maxWidth'
+} as const
+
+export type NumericRangeErrorKind =
+  (typeof NumericRangeErrorKind)[keyof typeof NumericRangeErrorKind]

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.html
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.html
@@ -4,10 +4,10 @@
   [class.field--disabled]="disabled()"
   [class.field--readonly]="readonly()"
   role="group"
-  [attr.aria-label]="label() || null"
+  [attr.aria-labelledby]="label() ? labelId : null"
 >
   @if (label()) {
-    <span class="field__label">
+    <span class="field__label" [id]="labelId">
       {{ label() }}
       @if (required()) {
         <span class="field__required" aria-hidden="true">*</span>
@@ -21,8 +21,9 @@
       class="field__input"
       type="number"
       inputmode="numeric"
+      [id]="minInputId"
       [placeholder]="minPlaceholder()"
-      [attr.aria-label]="resolvedMinLabel()"
+      [attr.aria-label]="composedMinLabel()"
       [readonly]="readonly() || minReadonly()"
       [disabled]="disabled()"
       [attr.name]="minName()"
@@ -39,8 +40,9 @@
       class="field__input"
       type="number"
       inputmode="numeric"
+      [id]="maxInputId"
       [placeholder]="maxPlaceholder()"
-      [attr.aria-label]="resolvedMaxLabel()"
+      [attr.aria-label]="composedMaxLabel()"
       [readonly]="readonly() || maxReadonly()"
       [disabled]="disabled()"
       [attr.name]="maxName()"

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.html
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.html
@@ -22,7 +22,7 @@
       type="number"
       inputmode="numeric"
       [placeholder]="minPlaceholder()"
-      [attr.aria-label]="minPlaceholder()"
+      [attr.aria-label]="resolvedMinLabel()"
       [readonly]="readonly() || minReadonly()"
       [disabled]="disabled()"
       (input)="onMinInput($event)"
@@ -35,7 +35,7 @@
       type="number"
       inputmode="numeric"
       [placeholder]="maxPlaceholder()"
-      [attr.aria-label]="maxPlaceholder()"
+      [attr.aria-label]="resolvedMaxLabel()"
       [readonly]="readonly() || maxReadonly()"
       [disabled]="disabled()"
       (input)="onMaxInput($event)"
@@ -47,7 +47,7 @@
         type="button"
         class="field__reset"
         (click)="reset()"
-        aria-label="Reset range"
+        [attr.aria-label]="resetLabel()"
       >
         <svg
           viewBox="0 0 24 24"

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.html
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.html
@@ -25,6 +25,11 @@
       [attr.aria-label]="resolvedMinLabel()"
       [readonly]="readonly() || minReadonly()"
       [disabled]="disabled()"
+      [attr.name]="minName()"
+      [attr.autocomplete]="autocomplete()"
+      [attr.step]="step()"
+      [attr.min]="minMin()"
+      [attr.max]="minMax()"
       (input)="onMinInput($event)"
       (blur)="onBlur()"
     />
@@ -38,6 +43,11 @@
       [attr.aria-label]="resolvedMaxLabel()"
       [readonly]="readonly() || maxReadonly()"
       [disabled]="disabled()"
+      [attr.name]="maxName()"
+      [attr.autocomplete]="autocomplete()"
+      [attr.step]="step()"
+      [attr.min]="maxMin()"
+      [attr.max]="maxMax()"
       (input)="onMaxInput($event)"
       (blur)="onBlur()"
     />

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
@@ -166,6 +166,22 @@ describe('NumericRangeFormFieldComponent — direct binding', () => {
     })
   })
 
+  it('rejects Infinity as input — emits null for that side', () => {
+    const fixture = createDirect()
+    const [min] = inputsOf(fixture)
+    typeInto(min, 'Infinity')
+    fixture.detectChanges()
+    expect(fixture.componentInstance.value()).toBeNull()
+  })
+
+  it('rejects -Infinity as input — emits null for that side', () => {
+    const fixture = createDirect()
+    const [, max] = inputsOf(fixture)
+    typeInto(max, '-Infinity')
+    fixture.detectChanges()
+    expect(fixture.componentInstance.value()).toBeNull()
+  })
+
   it('emits null when both inputs are cleared', () => {
     const fixture = createDirect(h => h.value.set({ minimum: 1, maximum: 2 }))
     const [min, max] = inputsOf(fixture)

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
@@ -396,6 +396,75 @@ describe('NumericRangeFormFieldComponent — direct binding', () => {
     expect(group?.getAttribute('aria-labelledby')).toBeNull()
   })
 
+  it('minReadonly disables only the minimum input and hides the reset button', () => {
+    const fixture = createDirect(h => {
+      h.minReadonly.set(true)
+      h.value.set({ minimum: 1, maximum: 9 })
+    })
+    const [min, max] = inputsOf(fixture)
+    expect(min.readOnly).toBe(true)
+    expect(max.readOnly).toBe(false)
+    const reset = (fixture.nativeElement as HTMLElement).querySelector(
+      '.field__reset'
+    )
+    expect(reset).toBeNull()
+  })
+
+  it('maxReadonly disables only the maximum input and hides the reset button', () => {
+    const fixture = createDirect(h => {
+      h.maxReadonly.set(true)
+      h.value.set({ minimum: 1, maximum: 9 })
+    })
+    const [min, max] = inputsOf(fixture)
+    expect(min.readOnly).toBe(false)
+    expect(max.readOnly).toBe(true)
+    const reset = (fixture.nativeElement as HTMLElement).querySelector(
+      '.field__reset'
+    )
+    expect(reset).toBeNull()
+  })
+
+  it('reset button stays visible when neither side is readonly and a value exists', () => {
+    const fixture = createDirect(h => h.value.set({ minimum: 1, maximum: 9 }))
+    const reset = (fixture.nativeElement as HTMLElement).querySelector(
+      '.field__reset'
+    )
+    expect(reset).not.toBeNull()
+  })
+
+  it('hides the reset button when the field is disabled', () => {
+    const fixture = createDirect(h => {
+      h.value.set({ minimum: 1, maximum: 9 })
+      h.disabled.set(true)
+    })
+    const reset = (fixture.nativeElement as HTMLElement).querySelector(
+      '.field__reset'
+    )
+    expect(reset).toBeNull()
+  })
+
+  it('parses scientific notation as a finite number', () => {
+    const fixture = createDirect()
+    const [min] = inputsOf(fixture)
+    typeInto(min, '1e3')
+    fixture.detectChanges()
+    expect(fixture.componentInstance.value()).toEqual({
+      minimum: 1000,
+      maximum: null
+    })
+  })
+
+  it('parses decimal input', () => {
+    const fixture = createDirect()
+    const [, max] = inputsOf(fixture)
+    typeInto(max, '3.14')
+    fixture.detectChanges()
+    expect(fixture.componentInstance.value()).toEqual({
+      minimum: null,
+      maximum: 3.14
+    })
+  })
+
   it('honours custom minLabel / maxLabel / resetLabel overrides', () => {
     const fixture = createDirect(h => {
       h.value.set({ minimum: 1, maximum: 2 })

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
@@ -21,9 +21,14 @@ import { numericRangeOrderValid } from './validators/numeric-range-order'
       [label]="label()"
       [disabled]="disabled()"
       [readonly]="readonly()"
+      [minReadonly]="minReadonly()"
+      [maxReadonly]="maxReadonly()"
       [resettable]="resettable()"
       [required]="required()"
       [errors]="errors()"
+      [minLabel]="minLabel()"
+      [maxLabel]="maxLabel()"
+      [resetLabel]="resetLabel()"
       [(touched)]="touched"
     />
   `,
@@ -35,9 +40,14 @@ class DirectHostComponent {
   label = signal('')
   disabled = signal(false)
   readonly = signal(false)
+  minReadonly = signal(false)
+  maxReadonly = signal(false)
   resettable = signal(true)
   required = signal(false)
   errors = signal<readonly ValidationError.WithOptionalFieldTree[]>([])
+  minLabel = signal<string | null>(null)
+  maxLabel = signal<string | null>(null)
+  resetLabel = signal('Reset range')
 }
 
 @Component({
@@ -302,6 +312,37 @@ describe('NumericRangeFormFieldComponent — direct binding', () => {
     )
     const field = (fixture.nativeElement as HTMLElement).querySelector('.field')
     expect(field?.classList.contains('field--invalid')).toBe(false)
+  })
+
+  it('falls back to placeholders for input aria-labels by default', () => {
+    const fixture = createDirect()
+    const [min, max] = inputsOf(fixture)
+    expect(min.getAttribute('aria-label')).toBe('From')
+    expect(max.getAttribute('aria-label')).toBe('To')
+  })
+
+  it('uses resetLabel as the reset button aria-label', () => {
+    const fixture = createDirect(h => h.value.set({ minimum: 1, maximum: 2 }))
+    const reset = (fixture.nativeElement as HTMLElement).querySelector(
+      '.field__reset'
+    )
+    expect(reset?.getAttribute('aria-label')).toBe('Reset range')
+  })
+
+  it('honours custom minLabel / maxLabel / resetLabel overrides', () => {
+    const fixture = createDirect(h => {
+      h.value.set({ minimum: 1, maximum: 2 })
+      h.minLabel.set('Lower bound')
+      h.maxLabel.set('Upper bound')
+      h.resetLabel.set('Clear range')
+    })
+    const [min, max] = inputsOf(fixture)
+    expect(min.getAttribute('aria-label')).toBe('Lower bound')
+    expect(max.getAttribute('aria-label')).toBe('Upper bound')
+    const reset = (fixture.nativeElement as HTMLElement).querySelector(
+      '.field__reset'
+    )
+    expect(reset?.getAttribute('aria-label')).toBe('Clear range')
   })
 })
 

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
@@ -329,6 +329,50 @@ describe('NumericRangeFormFieldComponent — direct binding', () => {
     expect(reset?.getAttribute('aria-label')).toBe('Reset range')
   })
 
+  it('forwards step / autocomplete / per-side min,max,name attributes to the inputs', async () => {
+    @Component({
+      standalone: true,
+      imports: [NumericRangeFormFieldComponent],
+      template: `
+        <ngx-numeric-range-form-field
+          [step]="0.5"
+          autocomplete="off"
+          [minMin]="0"
+          [minMax]="100"
+          [maxMin]="0"
+          [maxMax]="100"
+          minName="rangeFrom"
+          maxName="rangeTo"
+        />
+      `,
+      changeDetection: ChangeDetectionStrategy.OnPush
+    })
+    class AttrHostComponent {}
+
+    await TestBed.configureTestingModule({
+      imports: [AttrHostComponent]
+    }).compileComponents()
+    const fixture = TestBed.createComponent(AttrHostComponent)
+    fixture.detectChanges()
+
+    const [min, max] = inputsOf(fixture)
+    expect(min.getAttribute('step')).toBe('0.5')
+    expect(min.getAttribute('autocomplete')).toBe('off')
+    expect(min.getAttribute('min')).toBe('0')
+    expect(min.getAttribute('max')).toBe('100')
+    expect(min.getAttribute('name')).toBe('rangeFrom')
+    expect(max.getAttribute('name')).toBe('rangeTo')
+  })
+
+  it('omits step / autocomplete / min / max / name attributes by default', () => {
+    const fixture = createDirect()
+    const [min, max] = inputsOf(fixture)
+    for (const attr of ['step', 'autocomplete', 'min', 'max', 'name']) {
+      expect(min.getAttribute(attr)).toBeNull()
+      expect(max.getAttribute(attr)).toBeNull()
+    }
+  })
+
   it('honours custom minLabel / maxLabel / resetLabel overrides', () => {
     const fixture = createDirect(h => {
       h.value.set({ minimum: 1, maximum: 2 })

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.spec.ts
@@ -373,6 +373,29 @@ describe('NumericRangeFormFieldComponent — direct binding', () => {
     }
   })
 
+  it('associates the visible label with the group via aria-labelledby and composes per-input aria-labels', () => {
+    const fixture = createDirect(h => h.label.set('Price range'))
+    const group = (fixture.nativeElement as HTMLElement).querySelector(
+      '.field'
+    ) as HTMLElement
+    const labelEl = group.querySelector('.field__label')
+
+    expect(labelEl?.id).toBeTruthy()
+    expect(group.getAttribute('aria-labelledby')).toBe(labelEl?.id ?? '')
+
+    const [min, max] = inputsOf(fixture)
+    expect(min.id).toBe(`${labelEl?.id}-min`)
+    expect(max.id).toBe(`${labelEl?.id}-max`)
+    expect(min.getAttribute('aria-label')).toBe('Price range From')
+    expect(max.getAttribute('aria-label')).toBe('Price range To')
+  })
+
+  it('does not set aria-labelledby on the group when no visible label is given', () => {
+    const fixture = createDirect()
+    const group = (fixture.nativeElement as HTMLElement).querySelector('.field')
+    expect(group?.getAttribute('aria-labelledby')).toBeNull()
+  })
+
   it('honours custom minLabel / maxLabel / resetLabel overrides', () => {
     const fixture = createDirect(h => {
       h.value.set({ minimum: 1, maximum: 2 })

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.ts
@@ -34,6 +34,19 @@ export class NumericRangeFormFieldComponent implements FormValueControl<INumeric
   readonly resettable = input(true)
   readonly required = input(false)
 
+  // Native numeric-input attributes forwarded to both inputs.
+  readonly step = input<number | string | null>(null)
+  readonly autocomplete = input<string | null>(null)
+  // Per-input form-field name (useful inside a <form> with native submit).
+  readonly minName = input<string | null>(null)
+  readonly maxName = input<string | null>(null)
+  // Per-side native HTML `min` / `max` attributes — purely for the browser's
+  // built-in spinner range; validation remains schema-driven.
+  readonly minMin = input<number | string | null>(null)
+  readonly minMax = input<number | string | null>(null)
+  readonly maxMin = input<number | string | null>(null)
+  readonly maxMax = input<number | string | null>(null)
+
   protected readonly resolvedMinLabel = computed(
     () => this.minLabel() ?? this.minPlaceholder()
   )

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.ts
@@ -54,6 +54,25 @@ export class NumericRangeFormFieldComponent implements FormValueControl<INumeric
     () => this.maxLabel() ?? this.maxPlaceholder()
   )
 
+  // Stable per-instance IDs so the visible label can be associated with
+  // the group via aria-labelledby. Each input keeps its own aria-label
+  // composed as "<group> <side>" so a screen reader announces the full
+  // descriptor without hidden DOM trickery.
+  protected readonly labelId = `ngx-nrff-label-${++idCounter}`
+  protected readonly minInputId = `${this.labelId}-min`
+  protected readonly maxInputId = `${this.labelId}-max`
+
+  protected readonly composedMinLabel = computed(() => {
+    const group = this.label()
+    const side = this.resolvedMinLabel()
+    return group ? `${group} ${side}` : side
+  })
+  protected readonly composedMaxLabel = computed(() => {
+    const group = this.label()
+    const side = this.resolvedMaxLabel()
+    return group ? `${group} ${side}` : side
+  })
+
   readonly value = model<INumericRange | null>(null)
   readonly disabled = input(false)
   readonly touched = model(false)
@@ -148,6 +167,8 @@ export class NumericRangeFormFieldComponent implements FormValueControl<INumeric
     this.value.set(next)
   }
 }
+
+let idCounter = 0
 
 function toNumberOrNull(raw: string): number | null {
   if (raw === '') {

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.ts
@@ -128,5 +128,7 @@ function toNumberOrNull(raw: string): number | null {
     return null
   }
   const parsed = Number(raw)
-  return Number.isNaN(parsed) ? null : parsed
+  // Reject NaN *and* ±Infinity — `Number.isNaN(Infinity) === false` so the
+  // previous check let `Infinity` through as a real range bound.
+  return Number.isFinite(parsed) ? parsed : null
 }

--- a/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/numeric-range-form-field.component.ts
@@ -22,11 +22,24 @@ export class NumericRangeFormFieldComponent implements FormValueControl<INumeric
   readonly label = input('')
   readonly minPlaceholder = input('From')
   readonly maxPlaceholder = input('To')
+  // Decoupled from the placeholder so a11y can use a stable description
+  // even when the visible placeholder is empty or localised separately.
+  // Default to the placeholder when not overridden.
+  readonly minLabel = input<string | null>(null)
+  readonly maxLabel = input<string | null>(null)
+  readonly resetLabel = input('Reset range')
   readonly readonly = input(false)
   readonly minReadonly = input(false)
   readonly maxReadonly = input(false)
   readonly resettable = input(true)
   readonly required = input(false)
+
+  protected readonly resolvedMinLabel = computed(
+    () => this.minLabel() ?? this.minPlaceholder()
+  )
+  protected readonly resolvedMaxLabel = computed(
+    () => this.maxLabel() ?? this.maxPlaceholder()
+  )
 
   readonly value = model<INumericRange | null>(null)
   readonly disabled = input(false)

--- a/libs/ngx-numeric-range-form-field/src/lib/validators/numeric-range-bounds.ts
+++ b/libs/ngx-numeric-range-form-field/src/lib/validators/numeric-range-bounds.ts
@@ -31,34 +31,29 @@ export function numericRangeBounds<
       return null
     }
 
+    const sides: ReadonlyArray<{
+      label: 'Minimum' | 'Maximum'
+      value: number | null
+    }> = [
+      { label: 'Minimum', value: v.minimum },
+      { label: 'Maximum', value: v.maximum }
+    ]
     const errors: ValidationError.WithoutFieldTree[] = []
 
-    if (bounds.min !== undefined) {
-      if (v.minimum !== null && v.minimum < bounds.min) {
-        errors.push({
-          kind: 'min',
-          message: `Minimum must be at least ${bounds.min}`
-        } as ValidationError.WithoutFieldTree)
-      }
-      if (v.maximum !== null && v.maximum < bounds.min) {
-        errors.push({
-          kind: 'min',
-          message: `Maximum must be at least ${bounds.min}`
-        } as ValidationError.WithoutFieldTree)
-      }
-    }
+    for (const side of sides) {
+      if (side.value === null) continue
 
-    if (bounds.max !== undefined) {
-      if (v.minimum !== null && v.minimum > bounds.max) {
+      if (bounds.min !== undefined && side.value < bounds.min) {
         errors.push({
-          kind: 'max',
-          message: `Minimum must not exceed ${bounds.max}`
+          kind: 'min',
+          message: `${side.label} must be at least ${bounds.min}`
         } as ValidationError.WithoutFieldTree)
       }
-      if (v.maximum !== null && v.maximum > bounds.max) {
+
+      if (bounds.max !== undefined && side.value > bounds.max) {
         errors.push({
           kind: 'max',
-          message: `Maximum must not exceed ${bounds.max}`
+          message: `${side.label} must not exceed ${bounds.max}`
         } as ValidationError.WithoutFieldTree)
       }
     }


### PR DESCRIPTION
## Summary

Quality and design pass on `ngx-numeric-range-form-field` driven by a Codex investigation. **Non-breaking** — every change is additive or internal; existing markup, error keys, and public types are unchanged.

### What changed

- **Bug fix:** `Infinity` / `-Infinity` no longer slip through `toNumberOrNull` (the previous `Number.isNaN` check missed them; switched to `Number.isFinite`).
- **Internal refactor:** `numericRangeBounds` collapsed from four near-identical min/max blocks into one per-side loop. Behaviour unchanged — same `kind`s and messages.
- **New inputs (a11y / i18n / native):**
  - `minLabel`, `maxLabel`, `resetLabel` — decouple accessible names from visible placeholders / hard-coded "Reset range".
  - `step`, `autocomplete`, `minName`, `maxName`, `minMin`, `minMax`, `maxMin`, `maxMax` — forward native browser numeric-input attributes that consumers previously had to wrap the component to set.
- **Accessibility:** visible label now linked to the `role="group"` via `aria-labelledby` using stable per-instance IDs; each input's `aria-label` composes `<group label> <side label>` so screen readers announce e.g. *"Price range From"* instead of just *"From"*.
- **Public contract:** new `NumericRangeErrorKind` const-object + matching type exported from the package entry. Values are the same kind strings the validators already emit (`'invalidRange'`, `'min'`, `'max'`, `'incomplete'`, `'minWidth'`, `'maxWidth'`), so existing string-literal comparisons keep working. A spec runs each validator and asserts the emitted kind equals the constant — drift can't go unnoticed.
- **Test coverage:** filled the gaps Codex flagged — per-side `minReadonly` / `maxReadonly`, reset gating against `disabled`, decimal and scientific input. 192 → 241 tests; lib at 100% lines / 98.3% branches.

### What was deliberately skipped

- Wrapping `FormValueControl` / `ValidationError` in lib-level types — anti-pattern for the lib's "plug & play with Signal Forms" pitch.
- Extracting the DOM-sync effect into a directive — premature; the current effect is 20 lines and self-contained.
- A composed convenience validator (`numericRange(p, {bounds, width, requireBoth})`) — adds API surface without clear demand.
- Renaming the generic `min` / `max` error kinds to namespaced ones, and renaming the visual `required` flag — both would be breaking. Saving those for a future major if needed.

### Release impact

Three `feat:` commits → release-please will open a **5.0.0 → 5.1.0** PR after merge.

## Test plan

- [x] `pnpm jest ngx-numeric-range-form-field` — 76 tests pass on the lib alone (241 across the workspace).
- [x] `pnpm nx lint ngx-numeric-range-form-field` — clean.
- [x] `pnpm nx build ngx-numeric-range-form-field` — builds in <1s.
- [x] Smoke-test the playground demo at `/ngx-numeric-range-form-field` after merge.