### PR TITLE
ci: use RELEASE_PLEASE_TOKEN PAT so publish workflows auto-fire on release tags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,5 +18,12 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # Use a PAT instead of GITHUB_TOKEN so tag pushes that release-please
+          # makes are seen as "real" pushes — GitHub intentionally suppresses
+          # workflow triggers for events caused by GITHUB_TOKEN, which would
+          # otherwise leave each lib's `publish-*.yml` un-triggered after a
+          # release PR merge. With this PAT, the publish workflow fires
+          # automatically on the new tag.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json


### PR DESCRIPTION
## Summary

Switches release-please from the default `GITHUB_TOKEN` to a fine-grained PAT (`RELEASE_PLEASE_TOKEN`) so the tag pushes it makes are seen as "real" pushes and the per-lib `publish-*.yml` workflows trigger automatically.

## Why

GitHub intentionally suppresses workflow triggers for `push` events caused by `GITHUB_TOKEN`, to prevent recursive runs. release-please's flow is:

1. Open release PR.
2. After merge, push the `<lib>@x.y.z` tag with `GITHUB_TOKEN`.
3. The lib's `publish-<lib>.yml` workflow is supposed to fire on `push: tags:`, build, and `npm publish`.

Step 3 silently never runs — we hit it on `ngx-numeric-range-form-field@5.1.0` today. Workaround was `gh workflow run "publish ngx-numeric-range-form-field" --ref <tag>` after every release. With a PAT-authored push the tag is a normal push and the publish workflow runs automatically.

## Test plan

- [x] PAT scoped to this repo only: contents R/W, pull requests R/W, workflows R/W. Stored as `RELEASE_PLEASE_TOKEN` repo secret.
- [ ] Merge this PR.
- [ ] Next time release-please opens a release PR (any lib) and we merge it, observe the corresponding `publish-<lib>.yml` workflow fire automatically — no manual `workflow_dispatch` needed.
- [ ] Confirm npm picks up the new version.