### PR TITLE
feat(ngx-phone-form-field): quality-pass — fix active scroll, fix unparseable display, doc accuracy

### DIFF
--- a/libs/ngx-phone-form-field/CHANGELOG.md
+++ b/libs/ngx-phone-form-field/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to `ngx-phone-form-field` are documented here. This project
+adheres to [Semantic Versioning](https://semver.org/). Starting with `1.0.0`,
+entries are generated automatically by
+[release-please](https://github.com/googleapis/release-please) from
+[Conventional Commits](https://www.conventionalcommits.org/).
+
+## [1.0.0] - 2026-04-25
+
+First release from the
+[ngx-libs-workspace](https://github.com/dineeek/ngx-libs-workspace) monorepo. A
+Signal-Forms-native phone form field built on `libphonenumber-js/max`.
+
+### Added
+
+- `PhoneFormFieldComponent` — composite international phone field with country
+  picker + national-number input, exposed as a single E.164 string value.
+- AsYouType formatting via `libphonenumber-js/max` (full metadata,
+  line-type-aware).
+- Country auto-detect from `navigator.language`, overridable per field with
+  `initialCountry`.
+- `[countries]` input to restrict the picker to a subset of ISO 3166-1 alpha-2
+  codes; the same alphabet powers
+  [`phoneCountryIn`](./README.md#phonecountryinpath-countries).
+- Built-in search-by-name / dial-code popover with full keyboard navigation and
+  SVG flags via `country-flag-icons`. No Angular Material, no CDK.
+- Validator helpers: `phoneValid`, `phonePossible`, `phoneCountryIn`,
+  `phoneTypeIn`.
+- `CountryCode` and `NumberType` re-exported from the package entry so consumers
+  don't need a direct `libphonenumber-js` dependency.
+- Custom outlined field styling reskinnable via CSS custom properties
+  (`--ngx-pff-*`) — no `::ng-deep`, no global CSS leaks.
+- Standalone component, OnPush, signal-based inputs end-to-end,
+  `sideEffects: false`.
+
+### Notes
+
+- `@angular/forms/signals` is `@experimental 21.0.0`. Consumers of
+  `ngx-phone-form-field@1.x` adopt the same experimental surface.
+- Peer dependencies: Angular `>=21.0.0 <22.0.0`.

--- a/libs/ngx-phone-form-field/README.md
+++ b/libs/ngx-phone-form-field/README.md
@@ -96,12 +96,49 @@ export class PhoneDemoComponent {
 }
 ```
 
-The emitted value type is `string | null` — always a valid
-[E.164](https://en.wikipedia.org/wiki/E.164) string when set (e.g.
-`'+12015550123'`), `null` when the input is empty.
+The emitted value type is `string | null`:
+
+- **Empty input** — `null`.
+- **Fully valid** — a real [E.164](https://en.wikipedia.org/wiki/E.164) string
+  (e.g. `'+12015550123'`).
+- **In-progress typing** — a partial `+<dialcode><digits>` string while the user
+  is still entering enough digits for `libphonenumber-js` to recognise a number
+  (e.g. `'+12'` after typing the second digit). This lets consumers observe
+  progress in real time; pair the component with the `phoneValid()` validator
+  below if you need strict E.164 validity before accepting the value.
 
 If `initialCountry` is omitted, the field auto-detects the country from
 `navigator.language` and falls back to `'US'`.
+
+## Country codes & line types
+
+Anywhere this lib accepts a country (the `[countries]` input, `initialCountry`,
+the `phoneCountryIn` validator) it expects an **ISO 3166-1 alpha-2** code typed
+as `CountryCode` from
+[`libphonenumber-js`](https://www.npmjs.com/package/libphonenumber-js) — that's
+the same alphabet libphonenumber understands when it parses numbers, so the lib
+doesn't fork or re-define the set.
+
+Both types are **re-exported** from this package so you don't need to add
+`libphonenumber-js` as a direct dependency of your app:
+
+```typescript
+import { CountryCode, NumberType } from 'ngx-phone-form-field'
+//                                       ^ originally from libphonenumber-js/max
+
+const ALLOWED: readonly CountryCode[] = ['US', 'GB', 'DE', 'FR', 'JP', 'HR']
+const PHONE_TYPES: readonly NumberType[] = ['MOBILE', 'FIXED_LINE_OR_MOBILE']
+```
+
+| Type          | Re-exported from        | Used by                                                                                            |
+| ------------- | ----------------------- | -------------------------------------------------------------------------------------------------- |
+| `CountryCode` | `libphonenumber-js/max` | `[countries]`, `initialCountry`, `phoneCountryIn(path, countries)`, the `IPhoneCountry.iso2` field |
+| `NumberType`  | `libphonenumber-js/max` | `phoneTypeIn(path, types)` — values like `'MOBILE'`, `'FIXED_LINE'`, `'TOLL_FREE'`, etc.           |
+
+If you'd rather import directly from libphonenumber-js (e.g. you already use it
+elsewhere),
+`import type { CountryCode, NumberType } from 'libphonenumber-js/max'` is
+interchangeable.
 
 ## Restricting the country list
 
@@ -237,9 +274,16 @@ phoneForm = form<string | null>(this.phoneValue, p => {
 
 ### `phoneCountryIn(path, countries)`
 
-Restricts the parsed country to a whitelist of ISO 3166-1 alpha-2 codes. Fails
-with `{ kind: 'disallowedCountry' }`. Combine with `[countries]` on the
-component to also constrain the picker.
+Restricts the parsed country to a whitelist of
+[`CountryCode`](#country-codes--line-types) values. Fails with
+`{ kind: 'disallowedCountry' }`. Combine with `[countries]` on the component to
+also constrain the picker.
+
+**Note:** unparseable input (e.g. random text) is treated as "no detected
+country, therefore not allowed" and also fails with `disallowedCountry`. If
+you'd prefer unparseable values to surface as `invalidPhone` instead, compose
+this validator with `phoneValid(p)` first — `phoneValid` will own the
+parseability check and `phoneCountryIn` will only see input it can reason about.
 
 ![disallowed-country error](https://github.com/dineeek/ngx-libs-workspace/blob/main/libs/ngx-phone-form-field/screenshots/06-error-disallowed-country.png)
 

--- a/libs/ngx-phone-form-field/src/lib/country-picker/country-picker.component.html
+++ b/libs/ngx-phone-form-field/src/lib/country-picker/country-picker.component.html
@@ -68,7 +68,6 @@
         @let isActive = i === activeIndex();
         @let isSelected = entry.iso2 === selected();
         <li
-          #activeOption
           [id]="listboxId + '-opt-' + i"
           class="picker__option"
           [class.picker__option--active]="isActive"

--- a/libs/ngx-phone-form-field/src/lib/country-picker/country-picker.component.ts
+++ b/libs/ngx-phone-form-field/src/lib/country-picker/country-picker.component.ts
@@ -91,9 +91,9 @@ export class PhoneCountryPickerComponent {
         // viewChild bound to a template ref repeated on every <li> — that
         // pattern returns the *first* match in document order, so the scroll
         // never targeted the actually-active row.
-        const node = this.host.nativeElement.querySelector<HTMLLIElement>(
+        const node = this.host.nativeElement.querySelector(
           '.picker__option--active'
-        )
+        ) as HTMLLIElement | null
         if (node && typeof node.scrollIntoView === 'function') {
           node.scrollIntoView({ block: 'nearest' })
         }

--- a/libs/ngx-phone-form-field/src/lib/country-picker/country-picker.component.ts
+++ b/libs/ngx-phone-form-field/src/lib/country-picker/country-picker.component.ts
@@ -39,8 +39,6 @@ export class PhoneCountryPickerComponent {
 
   private readonly searchInputRef =
     viewChild<ElementRef<HTMLInputElement>>('searchInput')
-  private readonly activeOptionRef =
-    viewChild<ElementRef<HTMLLIElement>>('activeOption')
 
   protected readonly listboxId = `ngx-pff-listbox-${++idCounter}`
 
@@ -82,11 +80,20 @@ export class PhoneCountryPickerComponent {
     effect(() => {
       // Keep the activeIndex in range as the filtered list changes.
       const len = this.filtered().length
+      // Read activeIndex reactively so the scroll re-runs when the highlight
+      // moves via keyboard navigation, not just when the filtered list changes.
+      const idx = this.activeIndex()
       untracked(() => {
-        if (this.activeIndex() >= len) {
+        if (idx >= len) {
           this.activeIndex.set(len > 0 ? 0 : -1)
         }
-        const node = this.activeOptionRef()?.nativeElement
+        // Look up the active option directly via class instead of a singular
+        // viewChild bound to a template ref repeated on every <li> — that
+        // pattern returns the *first* match in document order, so the scroll
+        // never targeted the actually-active row.
+        const node = this.host.nativeElement.querySelector<HTMLLIElement>(
+          '.picker__option--active'
+        )
         if (node && typeof node.scrollIntoView === 'function') {
           node.scrollIntoView({ block: 'nearest' })
         }

--- a/libs/ngx-phone-form-field/src/lib/phone-form-field.component.spec.ts
+++ b/libs/ngx-phone-form-field/src/lib/phone-form-field.component.spec.ts
@@ -360,6 +360,17 @@ describe('PhoneFormFieldComponent — direct binding', () => {
     expect(fixture.componentInstance.value()).toBeNull()
   })
 
+  it('keeps a stripped fallback in the input when an external value cannot be parsed', () => {
+    const fixture = createDirect()
+    // Externally write a value libphonenumber-js cannot parse.
+    fixture.componentInstance.value.set('+1abc')
+    fixture.detectChanges()
+    // The input should NOT be blank — the previous behaviour was to clear
+    // it whenever parsing failed, leaving the model populated but the UI
+    // empty.
+    expect(numberInput(fixture).value).toBe('abc')
+  })
+
   it('clears the displayed input when the model is externally set to null', () => {
     const fixture = createDirect()
     typeInto(numberInput(fixture), '2015550123')

--- a/libs/ngx-phone-form-field/src/lib/phone-form-field.component.ts
+++ b/libs/ngx-phone-form-field/src/lib/phone-form-field.component.ts
@@ -193,9 +193,14 @@ export class PhoneFormFieldComponent implements FormValueControl<
     if (parsed?.country) {
       this.selectedCountry.set(parsed.country)
     }
+    // Strip the leading dial code from the raw value as the last-resort
+    // fallback so an unparseable external write (`'+1abc'`, partial typing
+    // emitted by the consumer) still shows *something* instead of clearing
+    // the input while the model holds a value.
+    const rawNational = v.replace(/^\+\d+/, '')
     const display = this.format()
-      ? (parsed?.formatNational() ?? parsed?.nationalNumber ?? '')
-      : (parsed?.nationalNumber ?? v.replace(/^\+\d+/, ''))
+      ? (parsed?.formatNational() ?? parsed?.nationalNumber ?? rawNational)
+      : (parsed?.nationalNumber ?? rawNational)
     this.displayValue.set(display)
     this.writeDom(display)
   }

--- a/libs/ngx-phone-form-field/src/lib/validators/phone-country-in.ts
+++ b/libs/ngx-phone-form-field/src/lib/validators/phone-country-in.ts
@@ -8,9 +8,20 @@ import {
 import { CountryCode, parsePhoneNumberFromString } from 'libphonenumber-js/max'
 
 /**
- * Signal Forms validator that rejects a phone number whose detected country
- * is not in the allowed list. Pass any subset of ISO 3166-1 alpha-2 country
- * codes (e.g. `['US', 'GB', 'HR']`). No-op when the value is `null` / empty.
+ * Signal Forms validator that rejects a phone number when its detected
+ * country is not in the allowed list. Pass any subset of ISO 3166-1
+ * alpha-2 country codes (e.g. `['US', 'GB', 'HR']`).
+ *
+ * Behaviour:
+ * - `null` / empty value — no-op (use `required(p)` if you need that
+ *   guarantee).
+ * - Parseable value with country in `allowed` — passes.
+ * - Parseable value with country NOT in `allowed` — emits
+ *   `{ kind: 'disallowedCountry' }`.
+ * - **Unparseable value** — also emits `{ kind: 'disallowedCountry' }` on
+ *   the principle "no detected country ⇒ not in the allowed list". Compose
+ *   with `phoneValid(p)` first if you'd prefer unparseable input to surface
+ *   as `'invalidPhone'` instead.
  */
 export function phoneCountryIn<
   TValue extends string | null | undefined,


### PR DESCRIPTION
## Summary

Quality and design pass on `ngx-phone-form-field` driven by a Codex investigation. **Non-breaking** — bug fixes + documentation accuracy. No public API changes.

### What changed

- **fix:** country picker — `viewChild('activeOption')` was bound to a template ref applied to every `<li>`, so Angular's singular-query rule resolved it to the *first* option in document order. Result: `scrollIntoView` never targeted the actually-highlighted row when keyboard navigation moved past the visible window. Switched to `host.querySelector('.picker__option--active')` and read `activeIndex()` reactively so the scroll fires on every keyboard move.
- **fix:** `applyExternalValue` — when an external write was unparseable (e.g. `'+1abc'`) the `format=true` path silently blanked the input while the model held the value. Strip the leading dial code as a last-resort fallback so the input always shows *something* when the model is non-null.
- **docs:** README's emitted-value contract was wrong — it claimed values are always valid E.164 when set, but the component intentionally emits partial `+<dialcode><digits>` strings during typing. Replaced with the accurate three-state contract (null / valid / in-progress).
- **docs:** new "Country codes & line types" section that names `CountryCode` / `NumberType`, says they're re-exported from `libphonenumber-js/max`, shows the import, and tabulates which inputs / validators consume each. Addresses the user-facing confusion about *where* the country-code alphabet comes from.
- **docs:** `phoneCountryIn` JSDoc + README now disclose that unparseable input also fails as `disallowedCountry`, and how to compose with `phoneValid()` if you'd rather route unparseable through `invalidPhone` instead. Behaviour unchanged.
- **docs:** add `libs/ngx-phone-form-field/CHANGELOG.md` with the 1.0.0 entry — the README was linking to a missing file. release-please will append future entries on top.

### Skipped (with reasoning)

- Refactor `PhoneFormFieldComponent` into a parser helper — same call as the numeric-range pass: structurally tidy, behaviourally inert, no payoff.
- Tightening the `detectCountry` 3-outcome test for `es-419` — intentional cross-Node-version tolerance; collapsing to one expected outcome makes the test brittle on CI Node minor bumps.

### Release impact

All commits are `fix:` / `docs:` — release-please will cut a **patch** release: `1.0.0 → 1.0.1`. With the PAT wiring from #46, the publish workflow will fire automatically when the release PR is merged.

## Test plan

- [x] `pnpm jest ngx-phone-form-field` — 102 lib tests pass (242 across the workspace).
- [x] `pnpm nx lint ngx-phone-form-field` — clean.
- [x] `pnpm nx build ngx-phone-form-field` — clean.
- [x] Smoke-test `/ngx-phone-form-field` on the deployed playground after merge: scroll through the country picker via keyboard and confirm the highlight stays in view as it moves down the list.